### PR TITLE
Fix Errors and FutureWarnings

### DIFF
--- a/tindeq_assessment/src/tindeq.py
+++ b/tindeq_assessment/src/tindeq.py
@@ -118,8 +118,8 @@ class TindeqProgressor(object):
 
         self.client = BleakClient(address)
         await self.client.connect()
-        success = await self.client.is_connected() 
-        if self.client.is_connected():
+        success = self.client.is_connected
+        if success:
             await self.client.start_notify(
                 uuid.UUID(self.notify_uuid),
                 self._notify_handler

--- a/tindeq_assessment/standalone.py
+++ b/tindeq_assessment/standalone.py
@@ -1424,7 +1424,6 @@ server = Server(apps, port=5000 )
 server.start()
 
 if __name__ == "__main__":
-    tornado.platform.asyncio.AsyncIOMainLoop().install()
     io_loop = tornado.ioloop.IOLoop.current()
     print('Opening Bokeh application on http://localhost:5006/')
     io_loop.add_callback(server.show, "/")

--- a/tindeq_assessment/standalone.py
+++ b/tindeq_assessment/standalone.py
@@ -1420,7 +1420,7 @@ cft = CFT()
 cft.make_gui(curdoc())
 
 apps = {'/': Application(FunctionHandler(cft.make_gui))}
-server = Server(apps, port=5000 )
+server = Server(apps, port=5006)
 server.start()
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes ```RuntimeError``` from deprecated ```tornado.platform.asyncio.AsyncIOMainLoop()```. Fixes ```OSError``` that shows up on MacOS > 12.0 from port 5000 being reserved by OS. Fixes ```FutureWarning``` from ```bleak```.